### PR TITLE
ci: add placeholder workflow to enable GitHub Actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,24 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches: [main]
+
+jobs:
+  # Dummy job to establish workflow
+  placeholder:
+    name: Placeholder Job
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Placeholder step
+        run: |
+          echo "This is a placeholder workflow"
+          echo "It will be replaced with the full CI/CD pipeline in PR #5"
+          echo "This exists to enable GitHub Actions for pull requests"


### PR DESCRIPTION
## Purpose
This PR adds a minimal placeholder GitHub Actions workflow to establish the CI/CD infrastructure.

## Why This Is Needed
- GitHub Actions only runs PR workflows if the workflow file exists in the base branch (main)
- PR #5 contains the full CI/CD pipeline but can't run because no workflow exists on main yet
- This placeholder enables GitHub Actions so PR #5's workflow will run

## What This Does
- Creates the `.github/workflows/` directory structure
- Adds a minimal `ci-cd.yml` workflow that just echoes a message
- Will be completely replaced by the full pipeline in PR #5

## Next Steps
1. Merge this PR to main
2. PR #5 will then be able to run its CI/CD workflow
3. PR #5's workflow will replace this placeholder with the full pipeline

This is a temporary bootstrapping step to enable GitHub Actions for the repository.